### PR TITLE
Some build fixes and improved README

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,9 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 # Extension JAR and core locations
-# Ant build.xml will put the JAR in its default location
-get_filename_component(ANT_BUILD_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../.." ABSOLUTE)
-set(ZSERIO_EXTENSION_JAR "${ANT_BUILD_ROOT}/build/compiler/extensions/cpp/11/jar/zserio_cpp.jar")
+# Use CMake build directory for Ant outputs to avoid path issues
+set(ZSERIO_EXTENSION_BUILD_DIR "${CMAKE_BINARY_DIR}/compiler/extensions")
+set(ZSERIO_EXTENSION_JAR "${ZSERIO_EXTENSION_BUILD_DIR}/cpp/11/jar/zserio_cpp.jar")
 set(ZSERIO_CORE_DIR "${CMAKE_BINARY_DIR}/zserio-2.16.1")
 set(ZSERIO_CORE_JAR "${ZSERIO_CORE_DIR}/zserio_libs/zserio_core.jar")
 

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ sudo dnf install java-11-openjdk-devel ant cmake gcc-c++
 The easiest way to build everything is using the provided build script:
 
 ```bash
-./build_and_test.bash
+./build_and_test.bash --clean
 ```
+
+Make sure to run a clean build the first time after cloning the repository. After that you can omit the `--clean` option.
 
 This will:
 - Check all prerequisites (Java, Ant, CMake, C++ compiler)
@@ -130,6 +132,7 @@ This will:
 
 For more control, you can use options:
 ```bash
+./build_and_test.bash --clean          # Clean build
 ./build_and_test.bash --help           # Show all options
 ./build_and_test.bash --debug          # Debug build
 ./build_and_test.bash --no-tests       # Skip tests
@@ -157,7 +160,7 @@ CMake options:
 
 There are three ways to use this C++11-safe extension:
 
-**Note:** After building with the new CMake system, the extension JAR will be at `build/extension/jar/zserio_cpp.jar` and the runtime library at `build/lib/libZserioCppRuntime.a`.
+**Note:** After building with the new CMake system, the extension JAR will be at `build/compiler/extensions/cpp/11/jar/zserio_cpp.jar` and the runtime library at `build/lib/libZserioCppRuntime.a`.
 
 After building both components, you can use the extension directly with the Java command:
 
@@ -171,7 +174,7 @@ java -cp "path/to/zserio_core.jar:path/to/zserio_cpp.jar" \
 
 Example:
 ```bash
-java -cp "../../../build/compiler/core/java/jar/zserio_core.jar:build/jar/zserio_cpp.jar" \
+java -cp "build/zserio-2.16.1/zserio_libs/zserio_core.jar:build/compiler/extensions/cpp/11/jar/zserio_cpp.jar" \
      zserio.tools.ZserioTool \
      -cpp11safe generated \
      -src schemas \

--- a/cmake/BuildExtension.cmake
+++ b/cmake/BuildExtension.cmake
@@ -58,6 +58,7 @@ function(build_zserio_extension)
         BUILD_COMMAND ${ANT_EXECUTABLE}
             -f "${EXTENSION_SOURCE_DIR}/build.xml"
             -Dzserio_core.jar_file=${ZSERIO_CORE_JAR}
+            -Dzserio_extensions.build_dir=${ZSERIO_EXTENSION_BUILD_DIR}
             jar_without_javadocs
         BUILD_IN_SOURCE TRUE
         INSTALL_COMMAND ""


### PR DESCRIPTION
Fixes an error that occured when the repo was checked out for example directly at user home folder, without a certain depth that the build script was expecting.
Updates the README to reflect zserio-2.16.1 inclusion in build folder.